### PR TITLE
Add top-level README to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ## Overview
 
-TTNN-Op-Runtime-Predictor contains models which predict the runtime of TTNN ops and an API to access them. These models are small MLPs (Multi Layer Perceptrons) trained using datasets generated from the `tt-metal` sweep framework. Each model is trained on a specific TTNN op. The op's input parameters are passed in and a runtime prediction is returned. These models can be queried for runtime predictions using an API in the repo that accepts JSON serialized op parameters.
+TTNN-Op-Runtime-Predictor contains models which predict the runtime of TTNN ops and an API to access them. These models are small MLPs (Multi Layer Perceptrons) trained using datasets generated from the [tt-metal](https://github.com/tenstorrent/tt-metal) [sweep framework](https://github.com/tenstorrent/tt-metal/blob/main/tests/README.md). Each model is trained on a specific TTNN op using [mlpack](https://www.mlpack.org/doc/index.html), a C++ machine learning library. The op's input parameters are passed in and a runtime prediction is returned. These models can be queried for runtime predictions using an API in the repo that accepts JSON serialized op parameters.
 
 ## Model Regeneration
 
 TTNN-Op-Runtime-Predictor contains scripts for dataset generation and model training / retraining. 
 
-1. **Generate Training Data:** Run sweep in `tt-metal` to collect op runtime. Models are trained on device kernel duration [ns] obtained from running sweeps with flag `--device-perf`.
+1. **Generate Training Data:** Run sweep in tt-metal to collect op runtime. Models are trained on device kernel duration [ns] obtained from running sweeps with flag `--device-perf`.
 2. **Preprocess Data:** Use script `create_dataset.py` in `train/python/model-regeneration` to aggregate collected data into a dataset.
 3. **Train Models:** Use scripts `train_new_mlp.cpp` or `retrain_mlp.cpp`  in `train/mlpack/model-regeneration` to train or retrain MLPs using the processed datasets.


### PR DESCRIPTION
Adding initial` README.md` to `ttnn-op-runtime-predictor` top level. Will add model regeneration examples in separate readme within `train` subdirectory for more details. 