### PR TITLE
Add SPDX License Headers to new files

### DIFF
--- a/interface-pybind/get_runtime_from_model_pybind.cpp
+++ b/interface-pybind/get_runtime_from_model_pybind.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "pybind11_json/pybind11_json.hpp"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/interface-pybind/usage.py
+++ b/interface-pybind/usage.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
 import ttnn_op_runtime_predictor as torp
 import json
 


### PR DESCRIPTION
Noticed failed on-push spdx license check, this PR adds license headers to `interface-pybind/get_runtime_from_model_pybind.cpp` and `interface-pybind/usage.py`. Reran on push workflow manually and passed.