### PR TITLE
Fix line in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-### Contributing to tt-npe
+### Contributing to ttnn-op-runtime-predictor
 
 ### Development Process
 


### PR DESCRIPTION
Updated line in `CONTRIBUTING.md` to say 'Contributing to ttnn-op-runtime-predictor' instead of 'Contributing to tt-npe'.